### PR TITLE
add fix for no specific label

### DIFF
--- a/cello/cello_predict.py
+++ b/cello/cello_predict.py
@@ -189,7 +189,7 @@ def main():
             for x in finalized_binary_results_df.columns
         ]
         ms_results_df['most_specific_cell_type'] = [
-            ou.cell_ontology().id_to_term[x].name
+            ou.cell_ontology().id_to_term[x].name if x != '' else 'Unknown'
             for x in ms_results_df['most_specific_cell_type']
         ]
 


### PR DESCRIPTION
if _select_one_most_specific has no prediction and appends '' in https://github.com/deweylab/CellO/blob/7d375810a0d310f3bdafc46a33ce7257860b882d/cello/cello.py#L738-L743

that seems to break https://github.com/deweylab/CellO/blob/7d375810a0d310f3bdafc46a33ce7257860b882d/cello/cello_predict.py#L191-L194

so I add this check and give the label unknown.